### PR TITLE
rework cert filter

### DIFF
--- a/src/ranch_ssl.erl
+++ b/src/ranch_ssl.erl
@@ -82,7 +82,9 @@ messages() -> {ssl, ssl_closed, ssl_error}.
 listen(Opts) ->
 	ranch:require([crypto, asn1, public_key, ssl]),
 	true = lists:keymember(cert, 1, Opts)
-		orelse lists:keymember(certfile, 1, Opts),
+		orelse lists:keymember(certfile, 1, Opts)
+        orelse lists:keymember(sni_hosts, 1, Opts)
+        orelse lists:keymember(sni_fun, 1, Opts),
 	Opts2 = ranch:set_option_default(Opts, backlog, 1024),
 	Opts3 = ranch:set_option_default(Opts2, send_timeout, 30000),
 	Opts4 = ranch:set_option_default(Opts3, send_timeout_close, true),


### PR DESCRIPTION
we shouldn't error out when the cert is missing if we have a snit_hosts
or an sni_fun option
